### PR TITLE
Add x-dataverse-key feature

### DIFF
--- a/src/main/java/nl/knaw/dans/dvauth/DdDataverseAuthenticatorApplication.java
+++ b/src/main/java/nl/knaw/dans/dvauth/DdDataverseAuthenticatorApplication.java
@@ -62,7 +62,7 @@ public class DdDataverseAuthenticatorApplication extends Application<DdDataverse
         //                .setRealm("Dataverse")
         //                .buildAuthFilter()));
 
-        var dataverseTokenAuthenticator = new DataverseTokenAuthenticator(dataverseDao, passwordValidator);
+        var dataverseTokenAuthenticator = new DataverseTokenAuthenticator(dataverseDao);
         var dataverseBasicAuthenticator = new DataverseBasicAuthenticator(dataverseDao, passwordValidator);
 
         environment.jersey().register(new AuthDynamicFeature(

--- a/src/main/java/nl/knaw/dans/dvauth/auth/CombinedAuthenticationFilter.java
+++ b/src/main/java/nl/knaw/dans/dvauth/auth/CombinedAuthenticationFilter.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2022 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.dvauth.auth;
+
+import io.dropwizard.auth.AuthFilter;
+import io.dropwizard.auth.basic.BasicCredentials;
+
+import javax.annotation.Nullable;
+import javax.annotation.Priority;
+import javax.ws.rs.Priorities;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.SecurityContext;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.Principal;
+import java.util.Base64;
+
+@Priority(Priorities.AUTHENTICATION)
+public class CombinedAuthenticationFilter<P extends Principal> extends AuthFilter<CombinedCredentials, P> {
+    private final String headerName;
+
+    public CombinedAuthenticationFilter(String headerName) {
+        this.headerName = headerName;
+    }
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) throws IOException {
+        var principals = getPrincipals(requestContext);
+
+        // not sure what will break if we put our custom auth method in here, so lets stick with BASIC_AUTH
+        if (!authenticate(requestContext, principals, SecurityContext.BASIC_AUTH)) {
+            throw unauthorizedHandler.buildException(prefix, realm);
+        }
+    }
+
+    private CombinedCredentials getPrincipals(ContainerRequestContext requestContext) {
+        var result = new CombinedCredentials();
+        var value = requestContext.getHeaders().getFirst(headerName);
+
+        if (value != null) {
+            result.setHeaderValue(new HeaderCredentials(value));
+        }
+
+        var basicCredentials = getBasicCredentials(requestContext.getHeaders().getFirst(HttpHeaders.AUTHORIZATION));
+
+        if (basicCredentials != null) {
+            result.setBasicCredentials(basicCredentials);
+        }
+
+        return result;
+    }
+
+    // Copied from io.dropwizard.auth.basic.BasicCredentialAuthFilter
+    @Nullable
+    private BasicCredentials getBasicCredentials(String header) {
+        if (header == null) {
+            return null;
+        }
+
+        final int space = header.indexOf(' ');
+        if (space <= 0) {
+            return null;
+        }
+
+        final String method = header.substring(0, space);
+        if (!prefix.equalsIgnoreCase(method)) {
+            return null;
+        }
+
+        final String decoded;
+        try {
+            decoded = new String(Base64.getDecoder().decode(header.substring(space + 1)), StandardCharsets.UTF_8);
+        }
+        catch (IllegalArgumentException e) {
+            logger.warn("Error decoding credentials", e);
+            return null;
+        }
+
+        // Decoded credentials is 'username:password'
+        final int i = decoded.indexOf(':');
+        if (i <= 0) {
+            return null;
+        }
+
+        final String username = decoded.substring(0, i);
+        final String password = decoded.substring(i + 1);
+        return new BasicCredentials(username, password);
+    }
+
+    public static class Builder<P extends Principal> extends
+        AuthFilterBuilder<CombinedCredentials, P, CombinedAuthenticationFilter<P>> {
+
+        private String headerName;
+
+        public Builder<P> setHeaderName(String headerName) {
+            this.headerName = headerName;
+            return this;
+        }
+
+        @Override
+        protected CombinedAuthenticationFilter<P> newInstance() {
+            return new CombinedAuthenticationFilter<>(headerName);
+        }
+    }
+}

--- a/src/main/java/nl/knaw/dans/dvauth/auth/CombinedAuthenticator.java
+++ b/src/main/java/nl/knaw/dans/dvauth/auth/CombinedAuthenticator.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2022 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.dvauth.auth;
+
+import io.dropwizard.auth.AuthenticationException;
+import io.dropwizard.auth.Authenticator;
+
+import java.util.ArrayList;
+import java.util.Optional;
+
+public class CombinedAuthenticator implements Authenticator<CombinedCredentials, AuthUser> {
+    private final DataverseBasicAuthenticator dataverseBasicAuthenticator;
+    private final DataverseTokenAuthenticator dataverseTokenAuthenticator;
+
+    public CombinedAuthenticator(DataverseBasicAuthenticator dataverseBasicAuthenticator, DataverseTokenAuthenticator dataverseTokenAuthenticator) {
+        this.dataverseBasicAuthenticator = dataverseBasicAuthenticator;
+        this.dataverseTokenAuthenticator = dataverseTokenAuthenticator;
+    }
+
+    @Override
+    public Optional<AuthUser> authenticate(CombinedCredentials credentials) throws AuthenticationException {
+        var results = new ArrayList<Optional<AuthUser>>();
+
+        // Only check the credentials if they are provided. If provided, they must all be correct
+        if (credentials.getBasicCredentials() != null) {
+            var basicResult = dataverseBasicAuthenticator.authenticate(credentials.getBasicCredentials());
+            results.add(basicResult);
+        }
+
+        if (credentials.getHeaderValue() != null) {
+            var headerResult = dataverseTokenAuthenticator.authenticate(credentials.getHeaderValue());
+            results.add(headerResult);
+        }
+
+        // no auth provided, this is bad
+        if (results.size() == 0) {
+            return Optional.empty();
+        }
+
+        // one of the results is not correct
+        if (results.contains(Optional.<AuthUser>empty())) {
+            return Optional.empty();
+        }
+
+        // TODO what if both methods are provided, but result in different users?
+        // the first result will be returned
+        return results.get(0);
+    }
+}

--- a/src/main/java/nl/knaw/dans/dvauth/auth/CombinedAuthenticator.java
+++ b/src/main/java/nl/knaw/dans/dvauth/auth/CombinedAuthenticator.java
@@ -18,7 +18,10 @@ package nl.knaw.dans.dvauth.auth;
 import io.dropwizard.auth.AuthenticationException;
 import io.dropwizard.auth.Authenticator;
 
+import javax.ws.rs.BadRequestException;
 import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Objects;
 import java.util.Optional;
 
 public class CombinedAuthenticator implements Authenticator<CombinedCredentials, AuthUser> {
@@ -32,6 +35,7 @@ public class CombinedAuthenticator implements Authenticator<CombinedCredentials,
 
     @Override
     public Optional<AuthUser> authenticate(CombinedCredentials credentials) throws AuthenticationException {
+
         var results = new ArrayList<Optional<AuthUser>>();
 
         // Only check the credentials if they are provided. If provided, they must all be correct
@@ -40,8 +44,8 @@ public class CombinedAuthenticator implements Authenticator<CombinedCredentials,
             results.add(basicResult);
         }
 
-        if (credentials.getHeaderValue() != null) {
-            var headerResult = dataverseTokenAuthenticator.authenticate(credentials.getHeaderValue());
+        if (credentials.getHeaderCredentials() != null) {
+            var headerResult = dataverseTokenAuthenticator.authenticate(credentials.getHeaderCredentials());
             results.add(headerResult);
         }
 
@@ -51,12 +55,12 @@ public class CombinedAuthenticator implements Authenticator<CombinedCredentials,
         }
 
         // one of the results is not correct
-        if (results.contains(Optional.<AuthUser>empty())) {
+        if (results.contains(Optional.<AuthUser> empty())) {
             return Optional.empty();
         }
 
-        // TODO what if both methods are provided, but result in different users?
         // the first result will be returned
         return results.get(0);
     }
+
 }

--- a/src/main/java/nl/knaw/dans/dvauth/auth/CombinedCredentials.java
+++ b/src/main/java/nl/knaw/dans/dvauth/auth/CombinedCredentials.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2022 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.dvauth.auth;
+
+import io.dropwizard.auth.basic.BasicCredentials;
+
+public class CombinedCredentials {
+    private BasicCredentials basicCredentials;
+    private HeaderCredentials headerCredentials;
+
+    public CombinedCredentials() {
+
+    }
+
+    public CombinedCredentials(BasicCredentials basicCredentials, HeaderCredentials headerCredentials) {
+        this.basicCredentials = basicCredentials;
+        this.headerCredentials = headerCredentials;
+    }
+
+    public BasicCredentials getBasicCredentials() {
+        return basicCredentials;
+    }
+
+    public void setBasicCredentials(BasicCredentials basicCredentials) {
+        this.basicCredentials = basicCredentials;
+    }
+
+    public HeaderCredentials getHeaderValue() {
+        return headerCredentials;
+    }
+
+    public void setHeaderValue(HeaderCredentials headerCredentials) {
+        this.headerCredentials = headerCredentials;
+    }
+}

--- a/src/main/java/nl/knaw/dans/dvauth/auth/CombinedCredentials.java
+++ b/src/main/java/nl/knaw/dans/dvauth/auth/CombinedCredentials.java
@@ -38,11 +38,11 @@ public class CombinedCredentials {
         this.basicCredentials = basicCredentials;
     }
 
-    public HeaderCredentials getHeaderValue() {
+    public HeaderCredentials getHeaderCredentials() {
         return headerCredentials;
     }
 
-    public void setHeaderValue(HeaderCredentials headerCredentials) {
+    public void setHeaderCredentials(HeaderCredentials headerCredentials) {
         this.headerCredentials = headerCredentials;
     }
 }

--- a/src/main/java/nl/knaw/dans/dvauth/auth/DataverseBasicAuthenticator.java
+++ b/src/main/java/nl/knaw/dans/dvauth/auth/DataverseBasicAuthenticator.java
@@ -26,13 +26,13 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Optional;
 
-public class DataverseAuthenticator implements Authenticator<BasicCredentials, AuthUser> {
-    private static final Logger log = LoggerFactory.getLogger(DataverseAuthenticator.class);
+public class DataverseBasicAuthenticator implements Authenticator<BasicCredentials, AuthUser> {
+    private static final Logger log = LoggerFactory.getLogger(DataverseBasicAuthenticator.class);
 
     private final DataverseDao dataverseDao;
     private final PasswordValidator passwordValidator;
 
-    public DataverseAuthenticator(DataverseDao dataverseDao, PasswordValidator passwordValidator) {
+    public DataverseBasicAuthenticator(DataverseDao dataverseDao, PasswordValidator passwordValidator) {
         this.dataverseDao = dataverseDao;
         this.passwordValidator = passwordValidator;
     }

--- a/src/main/java/nl/knaw/dans/dvauth/auth/DataverseTokenAuthenticator.java
+++ b/src/main/java/nl/knaw/dans/dvauth/auth/DataverseTokenAuthenticator.java
@@ -17,6 +17,7 @@ package nl.knaw.dans.dvauth.auth;
 
 import io.dropwizard.auth.AuthenticationException;
 import io.dropwizard.auth.Authenticator;
+import io.dropwizard.auth.chained.ChainedAuthFilter;
 import nl.knaw.dans.dvauth.core.PasswordValidator;
 import nl.knaw.dans.dvauth.db.DataverseDao;
 import org.slf4j.Logger;
@@ -28,11 +29,9 @@ public class DataverseTokenAuthenticator implements Authenticator<HeaderCredenti
     private static final Logger log = LoggerFactory.getLogger(DataverseTokenAuthenticator.class);
 
     private final DataverseDao dataverseDao;
-    private final PasswordValidator passwordValidator;
 
-    public DataverseTokenAuthenticator(DataverseDao dataverseDao, PasswordValidator passwordValidator) {
+    public DataverseTokenAuthenticator(DataverseDao dataverseDao) {
         this.dataverseDao = dataverseDao;
-        this.passwordValidator = passwordValidator;
     }
 
     @Override

--- a/src/main/java/nl/knaw/dans/dvauth/auth/DataverseTokenAuthenticator.java
+++ b/src/main/java/nl/knaw/dans/dvauth/auth/DataverseTokenAuthenticator.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2022 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.dvauth.auth;
+
+import io.dropwizard.auth.AuthenticationException;
+import io.dropwizard.auth.Authenticator;
+import nl.knaw.dans.dvauth.core.PasswordValidator;
+import nl.knaw.dans.dvauth.db.DataverseDao;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Optional;
+
+public class DataverseTokenAuthenticator implements Authenticator<HeaderCredentials, AuthUser> {
+    private static final Logger log = LoggerFactory.getLogger(DataverseTokenAuthenticator.class);
+
+    private final DataverseDao dataverseDao;
+    private final PasswordValidator passwordValidator;
+
+    public DataverseTokenAuthenticator(DataverseDao dataverseDao, PasswordValidator passwordValidator) {
+        this.dataverseDao = dataverseDao;
+        this.passwordValidator = passwordValidator;
+    }
+
+    @Override
+    public Optional<AuthUser> authenticate(HeaderCredentials value) throws AuthenticationException {
+        log.info("Authenticating user with token");
+
+        try {
+            return this.dataverseDao.findUserByApiToken(value.getValue())
+                .map(result -> {
+                    var user = new AuthUser(result.getUsername());
+                    log.info("User with name '{}' found", result.getUsername());
+                    return user;
+                });
+        }
+        catch (Exception e) {
+            log.error("Unable to verify credentials", e);
+            throw new AuthenticationException("Unable to verify credentials", e);
+        }
+    }
+}

--- a/src/main/java/nl/knaw/dans/dvauth/auth/HeaderCredentials.java
+++ b/src/main/java/nl/knaw/dans/dvauth/auth/HeaderCredentials.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2022 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.dvauth.auth;
+
+public class HeaderCredentials {
+    private final String value;
+
+    public HeaderCredentials(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/src/main/java/nl/knaw/dans/dvauth/core/TokenUser.java
+++ b/src/main/java/nl/knaw/dans/dvauth/core/TokenUser.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2022 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.dvauth.core;
+
+public class TokenUser {
+    private String username;
+
+    public TokenUser(String username) {
+        this.username = username;
+    }
+
+    public TokenUser() {
+
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    @Override
+    public String toString() {
+        return "TokenUser{" +
+            "username='" + username + '\'' +
+            '}';
+    }
+}

--- a/src/main/java/nl/knaw/dans/dvauth/db/DataverseDao.java
+++ b/src/main/java/nl/knaw/dans/dvauth/db/DataverseDao.java
@@ -16,6 +16,7 @@
 package nl.knaw.dans.dvauth.db;
 
 import nl.knaw.dans.dvauth.core.BuiltinUser;
+import nl.knaw.dans.dvauth.core.TokenUser;
 import org.jdbi.v3.sqlobject.config.RegisterBeanMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
@@ -28,4 +29,8 @@ public interface DataverseDao {
     @RegisterBeanMapper(BuiltinUser.class)
     Optional<BuiltinUser> findUserByName(@Bind("username") String username);
 
+    @SqlQuery("select a.useridentifier as username from apitoken t join authenticateduser a on a.id = t.authenticateduser_id "
+        + "where a.deactivated = false and t.disabled = false and t.tokenstring = :token")
+    @RegisterBeanMapper(TokenUser.class)
+    Optional<TokenUser> findUserByApiToken(@Bind("token") String token);
 }

--- a/src/test/java/nl/knaw/dans/dvauth/auth/CombinedAuthenticatorTest.java
+++ b/src/test/java/nl/knaw/dans/dvauth/auth/CombinedAuthenticatorTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (C) 2022 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.dvauth.auth;
+
+import io.dropwizard.auth.AuthenticationException;
+import io.dropwizard.auth.basic.BasicCredentials;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CombinedAuthenticatorTest {
+
+    @Test
+    void authenticate_should_return_empty_optional_if_no_methods_are_provided() throws Exception {
+        var dataverseTokenAuthenticator = Mockito.mock(DataverseTokenAuthenticator.class);
+        var dataverseBasicAuthenticator = Mockito.mock(DataverseBasicAuthenticator.class);
+        var authenticator = new CombinedAuthenticator(dataverseBasicAuthenticator, dataverseTokenAuthenticator);
+
+        var credentials = new CombinedCredentials(null, null);
+        var result = authenticator.authenticate(credentials);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void authenticate_should_return_AuthUser_if_only_basic_is_provided() throws Exception {
+        var dataverseTokenAuthenticator = Mockito.mock(DataverseTokenAuthenticator.class);
+        var dataverseBasicAuthenticator = Mockito.mock(DataverseBasicAuthenticator.class);
+        var authenticator = new CombinedAuthenticator(dataverseBasicAuthenticator, dataverseTokenAuthenticator);
+
+        // here we test if 1 method (basic) is provided, if it returns the user
+        // because the header credentials are empty, they will be ignored
+        Mockito.doReturn(Optional.of(new AuthUser("user")))
+            .when(dataverseBasicAuthenticator).authenticate(Mockito.any());
+
+        var credentials = new CombinedCredentials(new BasicCredentials("user", "password"), null);
+        var result = authenticator.authenticate(credentials);
+
+        assertFalse(result.isEmpty());
+    }
+
+    @Test
+    void authenticate_should_return_AuthUser_if_only_header_is_provided() throws Exception {
+        var dataverseTokenAuthenticator = Mockito.mock(DataverseTokenAuthenticator.class);
+        var dataverseBasicAuthenticator = Mockito.mock(DataverseBasicAuthenticator.class);
+        var authenticator = new CombinedAuthenticator(dataverseBasicAuthenticator, dataverseTokenAuthenticator);
+
+        // here we test if 1 method (basic) is provided, if it returns the user
+        // because the basic credentials are empty, they will be ignored
+        Mockito.doReturn(Optional.of(new AuthUser("user")))
+            .when(dataverseTokenAuthenticator).authenticate(Mockito.any());
+
+        var credentials = new CombinedCredentials(null, new HeaderCredentials("token"));
+        var result = authenticator.authenticate(credentials);
+
+        assertFalse(result.isEmpty());
+    }
+
+    @Test
+    void authenticate_should_return_AuthUser_from_basic_auth_if_both_methods_succeed() throws Exception {
+        var dataverseTokenAuthenticator = Mockito.mock(DataverseTokenAuthenticator.class);
+        var dataverseBasicAuthenticator = Mockito.mock(DataverseBasicAuthenticator.class);
+        var authenticator = new CombinedAuthenticator(dataverseBasicAuthenticator, dataverseTokenAuthenticator);
+
+        Mockito.doReturn(Optional.of(new AuthUser("user1")))
+            .when(dataverseTokenAuthenticator).authenticate(Mockito.any());
+
+        Mockito.doReturn(Optional.of(new AuthUser("user2")))
+            .when(dataverseBasicAuthenticator).authenticate(Mockito.any());
+
+        var credentials = new CombinedCredentials(new BasicCredentials("user", "pass"),
+            new HeaderCredentials("token"));
+
+        var result = authenticator.authenticate(credentials);
+
+        assertFalse(result.isEmpty());
+        // user2 is returned by the basic authentication
+        // TODO perhaps we should throw exceptions if the user names do not match?
+        assertEquals("user2", result.get().getName());
+    }
+
+    @Test
+    void authenticate_should_return_empty_optional_if_one_method_fails() throws Exception {
+        var dataverseTokenAuthenticator = Mockito.mock(DataverseTokenAuthenticator.class);
+        var dataverseBasicAuthenticator = Mockito.mock(DataverseBasicAuthenticator.class);
+        var authenticator = new CombinedAuthenticator(dataverseBasicAuthenticator, dataverseTokenAuthenticator);
+
+        // the token is provided, but does not match any users, so it will return an empty optional
+        Mockito.doReturn(Optional.empty())
+            .when(dataverseTokenAuthenticator).authenticate(Mockito.any());
+
+        Mockito.doReturn(Optional.of(new AuthUser("user2")))
+            .when(dataverseBasicAuthenticator).authenticate(Mockito.any());
+
+        var credentials = new CombinedCredentials(new BasicCredentials("user", "pass"),
+            new HeaderCredentials("token"));
+
+        var result = authenticator.authenticate(credentials);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void authenticate_should_propagate_AuthenticationException_from_authenticators() throws Exception {
+        var dataverseTokenAuthenticator = Mockito.mock(DataverseTokenAuthenticator.class);
+        var dataverseBasicAuthenticator = Mockito.mock(DataverseBasicAuthenticator.class);
+        var authenticator = new CombinedAuthenticator(dataverseBasicAuthenticator, dataverseTokenAuthenticator);
+
+        // the token is provided, but does not match any users, so it will return an empty optional
+        Mockito.doThrow(AuthenticationException.class)
+            .when(dataverseTokenAuthenticator).authenticate(Mockito.any());
+
+        Mockito.doReturn(Optional.of(new AuthUser("user2")))
+            .when(dataverseBasicAuthenticator).authenticate(Mockito.any());
+
+        var credentials = new CombinedCredentials(new BasicCredentials("user", "pass"),
+            new HeaderCredentials("token"));
+
+        assertThrows(AuthenticationException.class, () -> authenticator.authenticate(credentials));
+    }
+}

--- a/src/test/java/nl/knaw/dans/dvauth/auth/DataverseBasicAuthenticatorTest.java
+++ b/src/test/java/nl/knaw/dans/dvauth/auth/DataverseBasicAuthenticatorTest.java
@@ -29,14 +29,14 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-class DataverseAuthenticatorTest {
+class DataverseBasicAuthenticatorTest {
 
     final DataverseDao dataverseDao = Mockito.mock(DataverseDao.class);
     final PasswordValidator passwordValidator = Mockito.mock(PasswordValidator.class);
 
     @Test
-    void authenticate() throws AuthenticationException {
-        var authenticator = new DataverseAuthenticator(dataverseDao, passwordValidator);
+    void authenticate_should_return_empty_optional_by_default() throws AuthenticationException {
+        var authenticator = new DataverseBasicAuthenticator(dataverseDao, passwordValidator);
         var credentials = new BasicCredentials("user", "pass");
         var result = authenticator.authenticate(credentials);
 
@@ -44,8 +44,8 @@ class DataverseAuthenticatorTest {
     }
 
     @Test
-    void authenticateSuccess() throws AuthenticationException {
-        var authenticator = new DataverseAuthenticator(dataverseDao, passwordValidator);
+    void authenticate_should_return_AuthUser_if_user_is_found_in_db() throws AuthenticationException {
+        var authenticator = new DataverseBasicAuthenticator(dataverseDao, passwordValidator);
         var credentials = new BasicCredentials("user", "pass");
 
         Mockito.when(dataverseDao.findUserByName(Mockito.anyString()))
@@ -60,8 +60,8 @@ class DataverseAuthenticatorTest {
     }
 
     @Test
-    void authenticateFailedUserNotFound() throws AuthenticationException {
-        var authenticator = new DataverseAuthenticator(dataverseDao, passwordValidator);
+    void authenticate_should_return_empty_optional_if_user_is_not_in_db() throws AuthenticationException {
+        var authenticator = new DataverseBasicAuthenticator(dataverseDao, passwordValidator);
         var credentials = new BasicCredentials("user", "pass");
 
         Mockito.when(dataverseDao.findUserByName(Mockito.anyString()))
@@ -76,8 +76,8 @@ class DataverseAuthenticatorTest {
     }
 
     @Test
-    void authenticateFailedPasswordWrong() throws AuthenticationException {
-        var authenticator = new DataverseAuthenticator(dataverseDao, passwordValidator);
+    void authenticate_should_return_empty_optional_if_password_does_not_match() throws AuthenticationException {
+        var authenticator = new DataverseBasicAuthenticator(dataverseDao, passwordValidator);
         var credentials = new BasicCredentials("user", "pass");
 
         Mockito.when(dataverseDao.findUserByName(Mockito.anyString()))
@@ -92,8 +92,8 @@ class DataverseAuthenticatorTest {
     }
 
     @Test
-    void authenticateThrowsException() {
-        var authenticator = new DataverseAuthenticator(dataverseDao, passwordValidator);
+    void authenticate_should_throw_AuthenticationException_if_something_else_throws() {
+        var authenticator = new DataverseBasicAuthenticator(dataverseDao, passwordValidator);
         var credentials = new BasicCredentials("user", "pass");
 
         Mockito.when(dataverseDao.findUserByName(Mockito.anyString()))

--- a/src/test/java/nl/knaw/dans/dvauth/resources/AuthCheckResourceIntegrationTest.java
+++ b/src/test/java/nl/knaw/dans/dvauth/resources/AuthCheckResourceIntegrationTest.java
@@ -149,23 +149,7 @@ class AuthCheckResourceIntegrationTest {
     }
 
     @Test
-    void authenticate_should_return_401_for_valid_basic_auth_but_incorrect_header_key() {
-        var url = String.format("http://localhost:%s/", EXT.getLocalPort());
-        var auth = generateBasicAuthHeader("user001", "user001");
-
-        try (var result = EXT.client()
-            .target(url)
-            .request()
-            .header("authorization", auth)
-            .header("x-dataverse-key", "does-not-exist")
-            .post(Entity.entity("", MediaType.APPLICATION_JSON_TYPE))) {
-
-            assertEquals(401, result.getStatus());
-        }
-    }
-
-    @Test
-    void authenticate_should_return_401_for_invalid_basic_auth_but_correct_header_key() {
+    void authenticate_should_return_400_if_two_auth_methods_are_used() {
         var url = String.format("http://localhost:%s/", EXT.getLocalPort());
         var auth = generateBasicAuthHeader("user001", "user002");
 
@@ -176,23 +160,7 @@ class AuthCheckResourceIntegrationTest {
             .header("x-dataverse-key", "token1")
             .post(Entity.entity("", MediaType.APPLICATION_JSON_TYPE))) {
 
-            assertEquals(401, result.getStatus());
-        }
-    }
-
-    @Test
-    void authenticate_should_return_204_for_valid_basic_auth_and_header_key() {
-        var url = String.format("http://localhost:%s/", EXT.getLocalPort());
-        var auth = generateBasicAuthHeader("user001", "user001");
-
-        try (var result = EXT.client()
-            .target(url)
-            .request()
-            .header("authorization", auth)
-            .header("x-dataverse-key", "token1")
-            .post(Entity.entity("", MediaType.APPLICATION_JSON_TYPE))) {
-
-            assertEquals(204, result.getStatus());
+            assertEquals(400, result.getStatus());
         }
     }
 }

--- a/src/test/java/nl/knaw/dans/dvauth/resources/AuthCheckResourceIntegrationTest.java
+++ b/src/test/java/nl/knaw/dans/dvauth/resources/AuthCheckResourceIntegrationTest.java
@@ -46,7 +46,7 @@ class AuthCheckResourceIntegrationTest {
     }
 
     @Test
-    void testWithUsername() {
+    void authenticate_should_return_204_with_valid_credentials() {
         var url = String.format("http://localhost:%s/", EXT.getLocalPort());
         var auth = generateBasicAuthHeader("user001", "user001");
 
@@ -61,7 +61,7 @@ class AuthCheckResourceIntegrationTest {
     }
 
     @Test
-    void testWithUsernameButWrongPassword() {
+    void authenticate_should_return_401_for_invalid_password() {
         var url = String.format("http://localhost:%s/", EXT.getLocalPort());
         var auth = generateBasicAuthHeader("user001", "user002");
 
@@ -77,7 +77,7 @@ class AuthCheckResourceIntegrationTest {
     }
 
     @Test
-    void testWithUsernameButWrongUsername() {
+    void authenticate_should_return_401_for_invalid_username() {
         var url = String.format("http://localhost:%s/", EXT.getLocalPort());
         var auth = generateBasicAuthHeader("non-existing", "user002");
 
@@ -93,7 +93,7 @@ class AuthCheckResourceIntegrationTest {
     }
 
     @Test
-    void testWithoutCredentials() {
+    void authenticate_should_return_401_for_missing_credentials() {
         var url = String.format("http://localhost:%s/", EXT.getLocalPort());
 
         try (var result = EXT.client()
@@ -103,6 +103,96 @@ class AuthCheckResourceIntegrationTest {
 
             assertEquals(401, result.getStatus());
             assertNotNull(result.getHeaderString("WWW-Authenticate"));
+        }
+    }
+
+    @Test
+    void authenticate_should_return_204_for_dataverse_key() {
+        var url = String.format("http://localhost:%s/", EXT.getLocalPort());
+
+        try (var result = EXT.client()
+            .target(url)
+            .request()
+            .header("x-dataverse-key", "token1")
+            .post(Entity.entity("", MediaType.APPLICATION_JSON_TYPE))) {
+
+            assertEquals(204, result.getStatus());
+        }
+    }
+
+    @Test
+    void authenticate_should_return_401_for_invalid_dataverse_key() {
+        var url = String.format("http://localhost:%s/", EXT.getLocalPort());
+
+        try (var result = EXT.client()
+            .target(url)
+            .request()
+            .header("x-dataverse-key", "token2")
+            .post(Entity.entity("", MediaType.APPLICATION_JSON_TYPE))) {
+
+            assertEquals(401, result.getStatus());
+        }
+    }
+
+    @Test
+    void authenticate_should_return_401_for_missing_key() {
+        var url = String.format("http://localhost:%s/", EXT.getLocalPort());
+
+        try (var result = EXT.client()
+            .target(url)
+            .request()
+            .header("x-dataverse-key", "does-not-exist")
+            .post(Entity.entity("", MediaType.APPLICATION_JSON_TYPE))) {
+
+            assertEquals(401, result.getStatus());
+        }
+    }
+
+    @Test
+    void authenticate_should_return_401_for_valid_basic_auth_but_incorrect_header_key() {
+        var url = String.format("http://localhost:%s/", EXT.getLocalPort());
+        var auth = generateBasicAuthHeader("user001", "user001");
+
+        try (var result = EXT.client()
+            .target(url)
+            .request()
+            .header("authorization", auth)
+            .header("x-dataverse-key", "does-not-exist")
+            .post(Entity.entity("", MediaType.APPLICATION_JSON_TYPE))) {
+
+            assertEquals(401, result.getStatus());
+        }
+    }
+
+    @Test
+    void authenticate_should_return_401_for_invalid_basic_auth_but_correct_header_key() {
+        var url = String.format("http://localhost:%s/", EXT.getLocalPort());
+        var auth = generateBasicAuthHeader("user001", "user002");
+
+        try (var result = EXT.client()
+            .target(url)
+            .request()
+            .header("authorization", auth)
+            .header("x-dataverse-key", "token1")
+            .post(Entity.entity("", MediaType.APPLICATION_JSON_TYPE))) {
+
+            assertEquals(401, result.getStatus());
+        }
+    }
+
+    @Test
+    void authenticate_should_return_204_for_valid_basic_auth_and_header_key() {
+        var url = String.format("http://localhost:%s/", EXT.getLocalPort());
+        var auth = generateBasicAuthHeader("user001", "user001");
+
+        try (var result = EXT.client()
+            .target(url)
+            .request()
+            .header("authorization", auth)
+            .header("x-dataverse-key", "token1")
+            .post(Entity.entity("", MediaType.APPLICATION_JSON_TYPE))) {
+
+            assertEquals(204, result.getStatus());
         }
     }
 }

--- a/src/test/resources/test-etc/init.sql
+++ b/src/test/resources/test-etc/init.sql
@@ -1,11 +1,27 @@
 CREATE TABLE IF NOT EXISTS builtinuser (
-    id integer NOT NULL,
+    id integer NOT NULL PRIMARY KEY,
     encryptedpassword character varying(255),
     passwordencryptionversion integer,
     username character varying(255) NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS authenticateduser (
+    id integer NOT NULL PRIMARY KEY,
+    deactivated bool NOT NULL DEFAULT FALSE,
+    useridentifier varchar(255) NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS apitoken (
+    id integer NOT NULL PRIMARY KEY,
+    disabled bool NOT NULL DEFAULT FALSE,
+    tokenstring varchar(255) NOT NULL,
+    authenticateduser_id integer NOT NULL REFERENCES authenticateduser(id)
+);
+
+--- test data
 DELETE FROM builtinuser;
+DELETE FROM apitoken;
+DELETE FROM authenticateduser;
 
 INSERT INTO builtinuser (id, encryptedpassword, passwordencryptionversion, username)
 VALUES
@@ -14,4 +30,20 @@ VALUES
     (3, 'EwkfCo7O85qPEM/39U2hTw+3ehE=', 0, 'user002'),
     (4, 'CxMv+h/czMwZA554OwNVpibqxxA=', 0, 'user003');
 
+--- user001 is OK, permission granted
+--- user002 is disabled and deactivated, permission denied
+--- user003 is disabled and not deactivated, permission denied
+--- user004 is not disabled and deactivated, permission denied
+INSERT INTO authenticateduser (id, deactivated, useridentifier)
+VALUES
+    (1, false, 'user001'),
+    (2, true, 'user002'),
+    (3, false, 'user003'),
+    (4, true, 'user004');
 
+INSERT INTO apitoken (id, disabled, tokenstring, authenticateduser_id)
+VALUES
+    (1, false, 'token1', 1),
+    (2, true, 'token2', 2),
+    (3, true, 'token3', 3),
+    (4, false, 'token4', 4);


### PR DESCRIPTION
Fixes DD-1288

# Description of changes

Adds a new authentication method that works together with the basic authentication one. If either one is provided, they will be used individually. If both are provided, they must both be correct.

Note that it would be possible to authenticate as 2 different users in this case. TBD how to deal with this.


# How to test


# Related PRs
(Add links)
*

# Notify
@DANS-KNAW/dataversedans
