### PR TITLE
DD-1685: Check for expired token

### DIFF
--- a/src/main/java/nl/knaw/dans/dvauth/db/DataverseDao.java
+++ b/src/main/java/nl/knaw/dans/dvauth/db/DataverseDao.java
@@ -30,7 +30,7 @@ public interface DataverseDao {
     Optional<BuiltinUser> findUserByName(@Bind("username") String username);
 
     @SqlQuery("select a.useridentifier as username from apitoken t join authenticateduser a on a.id = t.authenticateduser_id "
-        + "where a.deactivated = false and t.disabled = false and t.tokenstring = :token")
+        + "where a.deactivated = false and t.disabled = false and t.expiretime > CURRENT_DATE and t.tokenstring = :token")
     @RegisterBeanMapper(TokenUser.class)
     Optional<TokenUser> findUserByApiToken(@Bind("token") String token);
 }

--- a/src/test/java/nl/knaw/dans/dvauth/resources/AuthCheckResourceIntegrationTest.java
+++ b/src/test/java/nl/knaw/dans/dvauth/resources/AuthCheckResourceIntegrationTest.java
@@ -127,6 +127,23 @@ class AuthCheckResourceIntegrationTest {
     }
 
     @Test
+    void authenticate_should_return_401_for_expired_dataverse_key() {
+        var url = String.format("http://localhost:%s/", EXT.getLocalPort());
+
+        try (var result = EXT.client()
+            .target(url)
+            .request()
+            .header("x-dataverse-key", "token5")
+            .post(Entity.entity("", MediaType.APPLICATION_JSON_TYPE))) {
+
+            // TODO fix this test
+            assertEquals(200, result.getStatus());
+            var response = result.readEntity(UserAuthResponse.class);
+            assertEquals("user005", response.getUserId());
+        }
+    }
+
+    @Test
     void authenticate_should_return_401_for_invalid_dataverse_key() {
         var url = String.format("http://localhost:%s/", EXT.getLocalPort());
 

--- a/src/test/java/nl/knaw/dans/dvauth/resources/AuthCheckResourceIntegrationTest.java
+++ b/src/test/java/nl/knaw/dans/dvauth/resources/AuthCheckResourceIntegrationTest.java
@@ -136,8 +136,23 @@ class AuthCheckResourceIntegrationTest {
             .header("x-dataverse-key", "token5")
             .post(Entity.entity("", MediaType.APPLICATION_JSON_TYPE))) {
 
-            // TODO fix this test
+            assertEquals(401, result.getStatus());
+        }
+    }
+
+    @Test
+    void authenticate_should_return_200_despite_expired_token() {
+        var url = String.format("http://localhost:%s/", EXT.getLocalPort());
+        var auth = generateBasicAuthHeader("user005", "user005");
+
+        try (var result = EXT.client()
+            .target(url)
+            .request()
+            .header("authorization", auth)
+            .post(Entity.entity("", MediaType.APPLICATION_JSON_TYPE))) {
+
             assertEquals(200, result.getStatus());
+
             var response = result.readEntity(UserAuthResponse.class);
             assertEquals("user005", response.getUserId());
         }

--- a/src/test/resources/test-etc/init.sql
+++ b/src/test/resources/test-etc/init.sql
@@ -29,24 +29,26 @@ VALUES
     (1, '$2a$10$nBBwLlls757bzXY30ts8duy1ymEJKhGxZgdWDBEOwmMkXXvv2C3CC', 1, 'dataverseAdmin'),
     (2, 'hN/rof975YOfV0wcZVXCrpU8ZlY=', 0, 'user001'),
     (3, 'EwkfCo7O85qPEM/39U2hTw+3ehE=', 0, 'user002'),
-    (4, 'CxMv+h/czMwZA554OwNVpibqxxA=', 0, 'user003');
+    (4, 'CxMv+h/czMwZA554OwNVpibqxxA=', 0, 'user003'),
+    (5, '5AJWRgVRLu9d0i0IxzTIcl0dFy4=', 0, 'user005');
 
 --- user001 is OK, permission granted
 --- user002 is disabled and deactivated, permission denied
 --- user003 is disabled and not deactivated, permission denied
 --- user004 is not disabled and deactivated, permission denied
+--- user005 has an expired token, permission denied when using token, granted when using username/password
 INSERT INTO authenticateduser (id, deactivated, useridentifier)
 VALUES
-    (5, false, 'user005'),
     (1, false, 'user001'),
     (2, true, 'user002'),
     (3, false, 'user003'),
-    (4, true, 'user004');
+    (4, true, 'user004'),
+    (5, false, 'user005');
 
 INSERT INTO apitoken (id, disabled, tokenstring, authenticateduser_id, expiretime)
 VALUES
-    (5, false, 'token5', 5, CURRENT_DATE - INTERVAL '1' DAY),
     (1, false, 'token1', 1, CURRENT_DATE + INTERVAL '1' DAY),
     (2, true, 'token2', 2, CURRENT_DATE + INTERVAL '1' DAY),
     (3, true, 'token3', 3, CURRENT_DATE + INTERVAL '1' DAY),
-    (4, false, 'token4', 4, CURRENT_DATE + INTERVAL '1' DAY);
+    (4, false, 'token4', 4, CURRENT_DATE + INTERVAL '1' DAY),
+    (5, false, 'token5', 5, CURRENT_DATE - INTERVAL '1' DAY);

--- a/src/test/resources/test-etc/init.sql
+++ b/src/test/resources/test-etc/init.sql
@@ -15,6 +15,7 @@ CREATE TABLE IF NOT EXISTS apitoken (
     id integer NOT NULL PRIMARY KEY,
     disabled bool NOT NULL DEFAULT FALSE,
     tokenstring varchar(255) NOT NULL,
+    expiretime timestamp NOT NULL,
     authenticateduser_id integer NOT NULL REFERENCES authenticateduser(id)
 );
 
@@ -36,14 +37,16 @@ VALUES
 --- user004 is not disabled and deactivated, permission denied
 INSERT INTO authenticateduser (id, deactivated, useridentifier)
 VALUES
+    (5, false, 'user005'),
     (1, false, 'user001'),
     (2, true, 'user002'),
     (3, false, 'user003'),
     (4, true, 'user004');
 
-INSERT INTO apitoken (id, disabled, tokenstring, authenticateduser_id)
+INSERT INTO apitoken (id, disabled, tokenstring, authenticateduser_id, expiretime)
 VALUES
-    (1, false, 'token1', 1),
-    (2, true, 'token2', 2),
-    (3, true, 'token3', 3),
-    (4, false, 'token4', 4);
+    (5, false, 'token5', 5, CURRENT_DATE - INTERVAL '1' DAY),
+    (1, false, 'token1', 1, CURRENT_DATE + INTERVAL '1' DAY),
+    (2, true, 'token2', 2, CURRENT_DATE + INTERVAL '1' DAY),
+    (3, true, 'token3', 3, CURRENT_DATE + INTERVAL '1' DAY),
+    (4, false, 'token4', 4, CURRENT_DATE + INTERVAL '1' DAY);


### PR DESCRIPTION
Fixes DD-1685: Check for expired token

# Description of changes


# How to test

See added unit tests. authenticate_should_return_401_for_expired_dataverse_key failed before the query was fixed.

PS: The tests create their own tables. This introduces a risk of false positives due to typos compared to the actual dvndb, or changes in the dvndb. So also tested after compilation and deploy with:

    update apitoken set expiretime = (CURRENT_DATE - INTERVAL '1' DAY) where id=999;
    curl -i -H "X-Dataverse-Key:xxx" -X POST http://localhost:20340

Use actual values for 999 and xxx and reset the `expiretime` after the test. Before the DB change, curl returns 200-OK, after the change 401-Unauthorized.

# Related PRs
(Add links)
*

# Notify
@DANS-KNAW/core-systems
